### PR TITLE
Use the current dir as default save_data dir

### DIFF
--- a/README
+++ b/README
@@ -62,11 +62,7 @@ Call the `get_data()` method to download and process the data.
 
     >>> sobi.get_data()
 
-It will take a few moments to download all the data. 
-
-Specify a destination path to save the data.
-
-    >>> sobi.path = '/path/to/sobi/download/files'
+It will take a few moments to download all the data.
 
 Save Your Data
 --------------
@@ -74,6 +70,10 @@ Save Your Data
 Export and save the data locally.
 
     >>> sobi.save_data()
+
+The default save location is the current directory. Specify a destination path to save the data.
+
+    >>> sobi.path = '/path/to/sobi/download/files'
 
 If you call `save_data()` without any parameters, it saves the data in JSON format under the filename:
 

--- a/README.md
+++ b/README.md
@@ -62,11 +62,7 @@ Call the `get_data()` method to download and process the data.
 
     >>> sobi.get_data()
 
-It will take a few moments to download all the data. 
-
-Specify a destination path to save the data.
-
-    >>> sobi.path = '/path/to/sobi/download/files'
+It will take a few moments to download all the data.
 
 Save Your Data
 --------------
@@ -74,6 +70,10 @@ Save Your Data
 Export and save the data locally.
 
     >>> sobi.save_data()
+
+The default save location is the current directory. Specify a destination path to save the data.
+
+    >>> sobi.path = '/path/to/sobi/download/files'
 
 If you call `save_data()` without any parameters, it saves the data in JSON format under the filename:
 

--- a/sobidata.py
+++ b/sobidata.py
@@ -23,7 +23,7 @@ class Sobi(object):
     def __init__(self):
         self.username=''
         self.password=''
-        self.path=''
+        self.path='.'
         self.auth = None
         self.data = {
             'routes': [],


### PR DESCRIPTION
- Update documentation

------

Previously, I was getting a permission denied error when trying to `save_data()` without having set `path` because the app was trying to write to the root directory.

From my googling, [it looks like](https://stackoverflow.com/a/32060632) this will be compatible on Windows, but I haven't been able to test that.