### PR TITLE
Include app name and version with API requests

### DIFF
--- a/sobidata.py
+++ b/sobidata.py
@@ -25,6 +25,10 @@ class Sobi(object):
         self.password=''
         self.path=''
         self.auth = None
+        self.request_params = {
+            'Application-Name': 'sobidata',
+            'Application-Version': version
+        }
         self.data = {
             'routes': [],
             'bikes': [],
@@ -65,7 +69,7 @@ class Sobi(object):
         self.make_auth()
         if polite == True: # wait before making the next query
             time.sleep(random.randrange(3)) 
-        response = requests.get(url, auth=self.auth)
+        response = requests.get(url, auth=self.auth, params=self.request_params)
         if response.status_code != 200:
             raise ValueError('HTTP Response code %s: %s' % (response.status_code, response.json()['error']))
         return response


### PR DESCRIPTION
This is requested by the [sobi dev docs]:
> Each application request which consumes data from the API must include information about the application name ('Application-Name' header) and version ('Application-Version')." At this point, the API does not require submission of this data, however this may change in the near future.

This is mentioned as a header, but when submitting them with `request.get(..., headers =...)`, I got a 400 response. Using `params`, I'm getting 200s back.

[sobi dev docs]: https://app.socialbicycles.com/developer/