### PR TITLE
Allow for named save files

### DIFF
--- a/README
+++ b/README
@@ -85,6 +85,10 @@ You can also save in several other formats by specifying the format as an option
     >>> sobi.save_data('xlsx') # Excel 2007 format via openpyxl module
     >>> sobi.save_data('csv') # CSV format - only saves routes
 
+You can also specify a name for file with the saved data by passing the optional `name` argument:
+    >>> sobi.save_data(name='hubs') # save to hubs.json
+    >>> sobi.save_data('csv', 'routes') # save to routes.csv
+
 Polite Mode
 -----------
 

--- a/README.md
+++ b/README.md
@@ -85,6 +85,10 @@ You can also save in several other formats by specifying the format as an option
     >>> sobi.save_data('xlsx') # Excel 2007 format via openpyxl module
     >>> sobi.save_data('csv') # CSV format - only saves routes
 
+You can also specify a name for file with the saved data by passing the optional `name` argument:
+    >>> sobi.save_data(name='hubs') # save to hubs.json
+    >>> sobi.save_data('csv', 'routes') # save to routes.csv
+
 Polite Mode
 -----------
 

--- a/sobidata.py
+++ b/sobidata.py
@@ -11,6 +11,7 @@ import datetime
 import json
 import logging
 import openpyxl
+import os
 import random
 import requests
 import time
@@ -201,9 +202,9 @@ class Sobi(object):
     def get_sorted_keys(self, dictionary):
         return sorted(dictionary.keys())
 
-    def save_data(self, ext='json'):
+    def save_data(self, ext='json', name='sobidata_export'):
         ext = ext.lower()
-        filename = '%s/sobidata_export.%s' % (self.path, ext)
+        filename = os.path.join(self.path, name + '.' + ext)
         contents = self.export_data(self.data, ext)
         with open(filename, 'w') as myfile:
             myfile.write(contents)


### PR DESCRIPTION
- Maintain previous name `sobidata_export` as default file name.
- Use `os.path.join` for cross-platform support.
- Update documentation